### PR TITLE
Replace trussed-rsa-alloc dependency with trussed-rsa-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 [Unreleased]: https://github.com/trussed-dev/piv-authenticator/compare/v0.5.3...HEAD
 
--
+- Replace `trussed-rsa-alloc` dependency with `trussed-rsa-types` for most use cases.
+  (Only the `virt` feature still requires `trussed-rsa-alloc`.)
 
 ## [v0.5.3][] (2025-07-31)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ heapless-bytes = "0.3.0"
 subtle = { version = "2", default-features = false }
 # TODO: only enable rsa features when needed
 trussed-core = { version = "0.1.0-rc.1", features = ["aes256-cbc", "chacha8-poly1305", "crypto-client", "ed255", "filesystem-client", "p256", "p384", "rsa2048", "rsa3072", "rsa4096", "shared-secret", "tdes", "x255"] }
+trussed-rsa-types = { version = "0.1", optional = true }
 trussed-rsa-alloc = { version = "0.3", features = ["raw"], optional = true }
 trussed-chunked = "0.2.0"
 trussed-hpke = "0.2.0"
@@ -64,11 +65,11 @@ apdu-dispatch = ["dep:apdu-app"]
 strict-pin = []
 std = []
 vpicc = ["std", "dep:vpicc", "virt", "dep:trussed-auth-backend"]
-virt = ["std", "trussed/virt", "dep:trussed-staging", "dep:trussed-auth-backend"]
+virt = ["std", "trussed/virt", "dep:trussed-staging", "dep:trussed-auth-backend", "dep:trussed-rsa-alloc"]
 pivy-tests = []
 opensc-tests = []
 alloc = []
-rsa = ["trussed-rsa-alloc", "alloc"]
+rsa = ["dep:trussed-rsa-types", "alloc"]
 delog  = ["dep:delog"]
 
 log-all = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -935,7 +935,7 @@ impl<T: Client> LoadedAuthenticator<'_, T> {
             AsymmetricAlgorithms::Rsa2048
             | AsymmetricAlgorithms::Rsa3072
             | AsymmetricAlgorithms::Rsa4096 => {
-                use trussed_rsa_alloc::RsaPublicParts;
+                use trussed_rsa_types::RsaPublicParts;
                 reply.expand(&[0x7F, 0x49])?;
                 let offset = reply.len();
                 let tmp = syscall!(self.trussed.serialize_key(
@@ -1088,7 +1088,7 @@ impl<T: Client> LoadedAuthenticator<'_, T> {
                 | AsymmetricAlgorithms::Rsa4096,
                 AsymmetricKeyReference::PivAuthentication,
             ) => {
-                use trussed_rsa_alloc::RsaImportFormat;
+                use trussed_rsa_types::RsaImportFormat;
                 let p = tlv::get_do(&[0x01], data).ok_or(Status::IncorrectDataParameter)?;
                 let q = tlv::get_do(&[0x02], data).ok_or(Status::IncorrectDataParameter)?;
                 let e = tlv::get_do(&[0x03], data).ok_or(Status::IncorrectDataParameter)?;


### PR DESCRIPTION
trussed-rsa-alloc is only required if both the rsa and the virt feature are enabled.  We cannot express this currently, but always pulling it in for the virt feature should be fine too.